### PR TITLE
Remove CNAME, switch hosting to Cloudflare Pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# wrangler deploy state (Cloudflare Pages CLI)
+.wrangler/

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-www.theinfinitebody.com


### PR DESCRIPTION
## Summary
- Remove `CNAME` (GH-Pages-specific; Cloudflare Pages doesn't use it).
- Add `.gitignore` for `.wrangler/` (Cloudflare Pages CLI deploy state).

## Context
Marketing site is now served entirely from the Cloudflare Pages project `tib-marketing`. Both apex (`theinfinitebody.com`) and `www` are attached as custom domains there with Google-issued certs. GitHub Pages was disabled in repo Settings → Pages (Source: None) and the custom domain was cleared.

## Test plan
- [ ] `https://theinfinitebody.com/` returns 200 (Server: cloudflare)
- [ ] `https://www.theinfinitebody.com/` returns 200 (Server: cloudflare)
- [ ] No regressions in apex/www content (compared to GH Pages version)

🤖 Generated with [Claude Code](https://claude.com/claude-code)